### PR TITLE
Update getExpr to account for an elif comment block

### DIFF
--- a/src/get-expr.ts
+++ b/src/get-expr.ts
@@ -122,6 +122,10 @@ const getExpr = function (key: string, expr: string) {
     return expr.trim()
   }
 
+  if (expr.indexOf('*/') > 0) {
+    return expr.slice(0, expr.indexOf('*/')).trim();
+  }
+
   /*
     When an assignment has a regex (ex: `#set _R /\s/`), skipRegex will not
     recognize it due to invalid syntax. Inserting the missing '=' solves this.


### PR DESCRIPTION
This will fix issues like `// #elif _CONDITION */` where the `*/` would crash the parser.

For example this would crash without these changes

```js
/* #if _MV
export const MV = true;
// #elif _MZ */
export const MZ = true;
// #endif
```